### PR TITLE
Fix "exports" main target

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,9 @@
     "url": "git@github.com:RaisinTen/perftrace.git"
   },
   "homepage": "https://github.com/RaisinTen/perftrace?tab=readme-ov-file#perftrace",
-  "main": "index.mjs",
-  "type": "module",
   "exports": {
-    "import": "index.mjs",
-    "require": "index.cjs"
+    "import": "./index.mjs",
+    "require": "./index.cjs"
   },
   "scripts": {
     "test": "npm run test:node && npm run test:browser",


### PR DESCRIPTION
For CJS `require("perftrace")`:
```
Error [ERR_INVALID_PACKAGE_TARGET]: Invalid "exports" main target "index.cjs" defined in the package config .../node_modules/perftrace/package.json; targets must start with "./"
```

For ESM `import ... from "perftrace"`:
```
Error [ERR_INVALID_PACKAGE_TARGET]: Invalid "exports" main target "index.mjs" defined in the package config .../node_modules/perftrace/package.json imported from ....mjs; targets must start with "./"
```