### PR TITLE
Swap dependency installation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
     - name: Install dependencies
       run: npm ci
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
     - run: npm test


### PR DESCRIPTION
The `npx playwright install --with-deps` command was producing this warning:

```
WARNING: It looks like you are running 'npx playwright install' without first
installing your project's dependencies.
```

so this change addresses that by running `npm ci` before running `npx playwright install --with-deps`.

Refs: https://github.com/RaisinTen/perftrace/actions/runs/10806970534/job/30191988723#step:4:7